### PR TITLE
Msg::verbose() lets you mute console messages

### DIFF
--- a/export/Log.h
+++ b/export/Log.h
@@ -76,6 +76,10 @@ namespace Msg {
   inline void print(const std::string &message)
   { print(SevMessage, message); }
 
+  //! Set the verbosity level of console output: 0 = do not echo anything
+  //! to the console; >=1 = echo all messages and warnings to the console.
+  FIELD3D_API void setVerbosity (int level=1);
+
 } // namespace Msg
 
 

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -57,10 +57,17 @@ FIELD3D_NAMESPACE_OPEN
 
 namespace Msg {
 
+
+static int verbosity = 1;
+
+
 //----------------------------------------------------------------------------//
 
 void print(Severity severity, const std::string &message)
 {
+  if (verbosity < 1)
+      return;
+
   switch(severity) {
   case SevWarning:
     cout << "WARNING: ";
@@ -72,6 +79,13 @@ void print(Severity severity, const std::string &message)
   }
 
   cout << message << endl;
+}
+
+
+
+void setVerbosity (int level)
+{
+  verbosity = level;
 }
 
 //----------------------------------------------------------------------------//


### PR DESCRIPTION
Some apps just want return codes and exceptions and for a library like Field3D to avoid printing anything to the console on its own.  This lets you turn it off.  The default behavior is the same as before.
