### PR TITLE
Fix compiler warning by removing unused variable

### DIFF
--- a/src/ClassFactory.cpp
+++ b/src/ClassFactory.cpp
@@ -164,7 +164,7 @@ void ClassFactory::registerFieldIO(CreateFieldIOFnPtr createFunc)
 FieldIO::Ptr 
 ClassFactory::createFieldIO(const std::string &className) const
 {
-  FieldIOFuncMap::const_iterator m = m_fieldIOs.begin();
+//  FieldIOFuncMap::const_iterator m = m_fieldIOs.begin();
   FieldIOFuncMap::const_iterator i = m_fieldIOs.find(className);
   if (i != m_fieldIOs.end())
     return i->second();


### PR DESCRIPTION
Feel free to change this from "commented out" to just deleted.  I just wasn't 100% sure that this was safe, but it looks unused to me (assuming that m_fieldIOs.begin() doesn't have any side effects you were trying to trigger).  
