### PR TITLE
Fix linking issue for Boost 1.50

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ IF ( CMAKE_HOST_WIN32 )
 # forced via a pragma.
 FIND_PACKAGE (Boost COMPONENTS regex thread)
 ELSE ()
-FIND_PACKAGE (Boost COMPONENTS regex thread program_options)
+FIND_PACKAGE (Boost COMPONENTS regex thread program_options system)
 FIND_PACKAGE (MPI)
 ENDIF ()
 


### PR DESCRIPTION
I'm not exactly sure why but if you don't include libboost_system linking fails with Boost 1.50. 

Here's the original error message prior to the "fix":
inking CXX executable create_and_write
/usr/bin/cmake -E cmake_link_script
CMakeFiles/create_and_write.dir/link.txt --verbose=1
/usr/bin/c++   -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions
-fstack-protector --param=ssp-buffer-size=4  -m64 -mtune=generic
-Wl,-z,relro  CMakeFiles/create_and_write.dir/apps/sample_code/create_and_write/main.cpp.o
 -o create_and_write -rdynamic libField3D.so.1.3 -lhdf5 -lz -lrt -lm
-lz -lIex -lHalf -lIlmThread -lImath -ldl -lboost_thread-mt
-lboost_program_options-mt
-Wl,-rpath,/builddir/build/BUILD/imageworks-Field3D-94d1bf3/build
/usr/bin/ld: CMakeFiles/create_and_write.dir/apps/sample_code/create_and_write/main.cpp.o:
undefined reference to symbol '_ZN5boost6system15system_categoryEv'
/usr/bin/ld: note: '_ZN5boost6system15system_categoryEv' is defined in
DSO /lib64/libboost_system-mt.so.1.50.0 so try adding it to the linker
command line
/lib64/libboost_system-mt.so.1.50.0: could not read symbols: Invalid operation
collect2: error: ld returned 1 exit status
