### PR TITLE
Explicitly specify the components needed from HDF5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ PROJECT ( field3d )
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake )
 
 FIND_PACKAGE (Doxygen)
-FIND_PACKAGE (HDF5)
+FIND_PACKAGE (HDF5 COMPONENTS C)
 IF ( CMAKE_HOST_WIN32 )
 # f3dinfo relies on program_options but don't include it, since
 # for some reason, unlike all the other boost components, a link is


### PR DESCRIPTION
In CMake 3.6, the default behavior of FindHDF5 will require more
components than Field3D needs.

See: https://cmake.org/gitweb?p=cmake.git;a=commitdiff;h=fdfb0c064929786fa1d09670cc4569b22c7c22ca
