### PR TITLE
Fix memory leaks in static variable pointers.

### DIFF
--- a/export/ClassFactory.h
+++ b/export/ClassFactory.h
@@ -44,6 +44,7 @@
 #ifndef _INCLUDED_Field3D_ClassFactory_H_
 #define _INCLUDED_Field3D_ClassFactory_H_
 
+#include <boost/scoped_ptr.hpp>
 #include <map>
 #include <vector>
 
@@ -161,7 +162,7 @@ private:
   NameVec m_fieldMappingIONames;
 
   //! Pointer to static instance
-  static ClassFactory *ms_instance;
+  static boost::scoped_ptr<ClassFactory> ms_instance;
 
 };
 

--- a/export/FieldCache.h
+++ b/export/FieldCache.h
@@ -46,6 +46,7 @@
 
 //----------------------------------------------------------------------------//
 
+#include <boost/scoped_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/foreach.hpp>
 
@@ -119,7 +120,7 @@ private:
   //! The cache itself. Maps a 'key' to a weak pointer and a raw pointer.
   Cache m_cache;
   //! The singleton instance
-  static FieldCache *ms_singleton;
+  static boost::scoped_ptr<FieldCache> ms_singleton;
   //! Mutex to prevent multiple allocaation of the singleton
   static boost::mutex ms_creationMutex;
   //! Mutex to prevent reading from and writing to the cache concurrently.
@@ -134,8 +135,8 @@ template <typename Data_T>
 FieldCache<Data_T>& FieldCache<Data_T>::singleton()
 {
   boost::mutex::scoped_lock lock(ms_creationMutex);
-  if (!ms_singleton) {
-    ms_singleton = new FieldCache;
+  if (ms_singleton.get() == NULL) {
+    ms_singleton.reset(new FieldCache);
   }
   return *ms_singleton;
 }

--- a/export/SparseFile.h
+++ b/export/SparseFile.h
@@ -46,6 +46,7 @@
 
 //----------------------------------------------------------------------------//
 
+#include <boost/scoped_ptr.hpp>
 #include <deque>
 #include <list>
 #include <vector>
@@ -494,7 +495,7 @@ private:
   SparseFileManager();
 
   //! Pointer to singleton
-  static SparseFileManager *ms_singleton;
+  static boost::scoped_ptr<SparseFileManager> ms_singleton;
 
   //! Adds the newly loaded block to the cache, managed by the paging algorithm
   void addBlockToCache(DataTypeEnum blockType, int fileId, int blockIdx);

--- a/src/ClassFactory.cpp
+++ b/src/ClassFactory.cpp
@@ -56,7 +56,7 @@ FIELD3D_NAMESPACE_OPEN
 // Static instances
 //----------------------------------------------------------------------------//
 
-ClassFactory* ClassFactory::ms_instance = NULL;
+boost::scoped_ptr<ClassFactory> ClassFactory::ms_instance;
 
 //----------------------------------------------------------------------------//
 // ClassFactory implementations
@@ -277,8 +277,9 @@ ClassFactory::createFieldMappingIO(const std::string &className) const
 ClassFactory& 
 ClassFactory::singleton()
 { 
-  if (!ms_instance)
-    ms_instance = new ClassFactory;
+  if (ms_instance.get() == NULL) {
+    ms_instance.reset(new ClassFactory);
+  }
   return *ms_instance;
 }
 

--- a/src/FieldCache.cpp
+++ b/src/FieldCache.cpp
@@ -58,7 +58,7 @@ boost::mutex FieldCache<Data_T>::ms_creationMutex;
 template <typename Data_T>
 boost::mutex FieldCache<Data_T>::ms_accessMutex;
 template <typename Data_T>
-FieldCache<Data_T>* FieldCache<Data_T>::ms_singleton;
+boost::scoped_ptr<FieldCache<Data_T> > FieldCache<Data_T>::ms_singleton;
 
 template class FieldCache<half>;
 template class FieldCache<float>;

--- a/src/SparseFile.cpp
+++ b/src/SparseFile.cpp
@@ -57,7 +57,7 @@ FIELD3D_NAMESPACE_OPEN
 // Static instances
 //----------------------------------------------------------------------------//
 
-SparseFileManager *SparseFileManager::ms_singleton = 0;
+boost::scoped_ptr<SparseFileManager> SparseFileManager::ms_singleton;
 
 //----------------------------------------------------------------------------//
 // SparseFileManager
@@ -65,8 +65,8 @@ SparseFileManager *SparseFileManager::ms_singleton = 0;
 
 SparseFileManager & SparseFileManager::singleton()
 { 
-  if (!ms_singleton) {
-    ms_singleton = new SparseFileManager;
+  if (ms_singleton.get() == NULL) {
+    ms_singleton.reset(new SparseFileManager);
   }
   return *ms_singleton;
 }


### PR DESCRIPTION
Hi,

over at Autodesk we run Field3D under Valgrind, and we discovered that Field3D leaks a number of singletons in static variable pointers. This patch fixes these memory leaks by replacing the raw pointers with boost::scoped_ptr that will properly delete the objects when the library is unloaded.