### PR TITLE
Add C++11 flag

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -36,7 +36,7 @@ from BuildSupport import *
 
 # ------------------------------------------------------------------------------
 
-env = Environment()
+env = Environment(CXXFLAGS="-std=c++11")
 
 Export("env")
 


### PR DESCRIPTION
C++11 is requires to build field3d with the latest ilmbase, since ilmbase is written in C++11 now.