### PR TITLE
Update to allow FindILMBase.cmake to work with modern cmake

### DIFF
--- a/cmake/FindILMBase.cmake
+++ b/cmake/FindILMBase.cmake
@@ -37,8 +37,8 @@
 #  ILMBASE_FOUND - true if ILMBASE was found on the system
 #  ILMBASE_LIBRARY_DIRS - the full set of library directories
 
-FIND_PATH ( Ilmbase_Base_Dir include/OpenEXR/IlmBaseConfig.h
-  ENV ILMBASE_ROOT
+FIND_PATH ( Ilmbase_Base_Dir NAMES include/OpenEXR/IlmBaseConfig.h
+  PATHS ${ILMBASE_ROOT}
   )
 
 IF ( Ilmbase_Base_Dir )
@@ -47,7 +47,7 @@ IF ( Ilmbase_Base_Dir )
     ${Ilmbase_Base_Dir}/include
     ${Ilmbase_Base_Dir}/include/OpenEXR
     CACHE STRING "ILMBase include directories")
-  SET ( ILMBASE_LIBRARY_DIRS ${Ilmbase_Base_Dir}/lib
+  SET ( ILMBASE_LIBRARY_DIRS ${Ilmbase_Base_Dir}/lib64
     CACHE STRING "ILMBase library directories")
   SET ( ILMBASE_FOUND TRUE )
 


### PR DESCRIPTION
When attempting to compile Field3D support into OpenImageIO, I was unable to get Field3D to be found with the above cmake file.

The following changes I am suggesting in order to allow it to be found more accurately in a modern environment.